### PR TITLE
Add new chplVersion field

### DIFF
--- a/Mason.toml
+++ b/Mason.toml
@@ -1,6 +1,7 @@
 [brick]
 name = "LinearAlgebraJama"
 version = "0.1.0"
+chplVersion = "1.16.0"
 author = "ct-clmsn"
 
 [dependencies]


### PR DESCRIPTION
Recent work on mason added a 'chplVersion' field that allows packages to indicate compatible versions of Chapel.